### PR TITLE
slightly altered prob_map --> instances treatment 

### DIFF
--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -658,7 +658,7 @@ class SegmentationJupyter(object):
                 #----------- do not count it as inference time -------------------------------#
                 #------------remove if said model weights get eventually bundled and downloaded at package import time ---------#
 
-                #_ = self.pred.run_image_stack_jupyter(self.imgs_cut[:1], model_name, clean_border=False)
+                _ = self.pred.run_image_stack_jupyter(self.imgs_cut[:1], model_name, clean_border=False)
 
                 #----------- now sync cuda and start measuring inference time --------#
                 self.gpu_sync()

--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -658,7 +658,7 @@ class SegmentationJupyter(object):
                 #----------- do not count it as inference time -------------------------------#
                 #------------remove if said model weights get eventually bundled and downloaded at package import time ---------#
 
-                _ = self.pred.run_image_stack_jupyter(self.imgs_cut[:1], model_name, clean_border=False)
+                #_ = self.pred.run_image_stack_jupyter(self.imgs_cut[:1], model_name, clean_border=False)
 
                 #----------- now sync cuda and start measuring inference time --------#
                 self.gpu_sync()

--- a/midap/segmentation/bmz_segmentator_jupyter.py
+++ b/midap/segmentation/bmz_segmentator_jupyter.py
@@ -266,11 +266,11 @@ class BMZSegmentationJupyter(base_segmentator.SegmentationPredictor):
             sample = predict(model=pp, inputs={input_id: x_bcyx})
             arrays = sample.as_arrays()  
 
-            #lab = self._to_labels(arrays)
-            #lab = self._embed_back(lab, info)
+            lab = self._to_labels(arrays)
+            lab = self._embed_back(lab, info)
 
-            lab = self._embed_back(arrays, info)
-            lab = self._to_labels(lab)
+            #lab = self._embed_back(arrays, info)
+            #lab = self._to_labels(lab)
             
             if bmz_id == "conscientious-seashell":
                 H0, W0 = int(info["H0"]), int(info["W0"])

--- a/midap/segmentation/bmz_segmentator_jupyter.py
+++ b/midap/segmentation/bmz_segmentator_jupyter.py
@@ -168,7 +168,7 @@ class BMZSegmentationJupyter(base_segmentator.SegmentationPredictor):
     
         if "output0" in out_arrays:
             p = np.asarray(out_arrays["output0"])
-            p2d = self._extract_2d(a, prefer_foreground=True).astype("float32")
+            p2d = self._extract_2d(p, prefer_foreground=True).astype("float32")
             try:
                 thr = float(threshold_otsu(p2d))
             except Exception:

--- a/midap/segmentation/bmz_segmentator_jupyter.py
+++ b/midap/segmentation/bmz_segmentator_jupyter.py
@@ -145,32 +145,76 @@ class BMZSegmentationJupyter(base_segmentator.SegmentationPredictor):
     
     
     def _to_labels(self, out_arrays: dict) -> np.ndarray:
-       
-        def _as_2d_any(arr):
-            return self._extract_2d(arr, prefer_foreground=False)
+
+
+        from skimage.filters import threshold_otsu
+        from skimage.morphology import remove_small_objects, binary_closing, square
+        from scipy.ndimage import binary_fill_holes
+        from skimage.measure import label as cc_label
+        import numpy as np
 
         def _as_2d_prob(arr):
-            return self._extract_2d(arr, prefer_foreground=True).astype("float32")
-        
+            a = self._extract_2d(arr, prefer_foreground=True).astype("float32")
+            if not np.isfinite(a).all():
+                a = np.nan_to_num(a, nan=0.0, posinf=0.0, neginf=0.0)
+            return a
+
+        if "masks" in out_arrays:
+            m = np.asarray(self._extract_2d(out_arrays["masks"], prefer_foreground=False))
+            if m.ndim == 2 and m.dtype.kind in "ui":
+                return m.astype(np.uint32)
+
         if "output0" in out_arrays:
-            a = np.asarray(out_arrays["output0"])
-            # reduce to 2D: pick the likely foreground channel from (C,H,W)
-            a2d = self._extract_2d(a, prefer_foreground=True).astype("float32")
-            try:
-                from skimage.filters import threshold_otsu
-                thr = float(threshold_otsu(a2d))
-            except Exception:
-                thr = float(a2d.mean() + 0.5 * a2d.std())
-            mask = a2d > thr
-            from skimage.morphology import remove_small_objects
-            mask = remove_small_objects(mask, 16)
-            try:
-                from scipy.ndimage import binary_fill_holes
-                mask = binary_fill_holes(mask)
-            except Exception:
-                pass
-            from skimage.measure import label
-            return label(mask).astype(np.uint32)
+            p = _as_2d_prob(out_arrays["output0"])
+        else:
+            p = None
+            for v in out_arrays.values():
+                if isinstance(v, np.ndarray):
+                    p = _as_2d_prob(v)
+                    break
+            if p is None:
+                raise RuntimeError("BMZ model produced no usable array outputs.")
+
+        if p.size == 0 or p.max() == p.min():
+            return np.zeros_like(p, dtype=np.uint32)
+
+        try:
+            thr = float(threshold_otsu(p))
+        except Exception:
+            thr = float(p.mean() + 0.5 * p.std())
+
+        mask = p > thr
+        mask = binary_fill_holes(mask)
+        mask = binary_closing(mask, footprint=square(3))
+        mask = remove_small_objects(mask, min_size=16)
+
+        return cc_label(mask).astype(np.uint32)
+
+        #def _as_2d_any(arr):
+        #    return self._extract_2d(arr, prefer_foreground=False)
+
+        #def _as_2d_prob(arr):
+        #    return self._extract_2d(arr, prefer_foreground=True).astype("float32")
+        
+        #if "output0" in out_arrays:
+        #    a = np.asarray(out_arrays["output0"])
+        #    # reduce to 2D: pick the likely foreground channel from (C,H,W)
+        #    a2d = self._extract_2d(a, prefer_foreground=True).astype("float32")
+        #    try:
+        #        from skimage.filters import threshold_otsu
+        #        thr = float(threshold_otsu(a2d))
+        #    except Exception:
+        #        thr = float(a2d.mean() + 0.5 * a2d.std())
+        #    mask = a2d > thr
+        #    from skimage.morphology import remove_small_objects
+        #    mask = remove_small_objects(mask, 16)
+        #    try:
+        #        from scipy.ndimage import binary_fill_holes
+        #        mask = binary_fill_holes(mask)
+        #    except Exception:
+        #        pass
+        #    from skimage.measure import label
+        #    return label(mask).astype(np.uint32)
             
         #if "masks" in out_arrays:
         #    m = np.asarray(_as_2d_any(out_arrays["masks"]))

--- a/midap/segmentation/bmz_segmentator_jupyter.py
+++ b/midap/segmentation/bmz_segmentator_jupyter.py
@@ -266,9 +266,12 @@ class BMZSegmentationJupyter(base_segmentator.SegmentationPredictor):
             sample = predict(model=pp, inputs={input_id: x_bcyx})
             arrays = sample.as_arrays()  
 
-            lab = self._to_labels(arrays)
-            lab = self._embed_back(lab, info)
+            #lab = self._to_labels(arrays)
+            #lab = self._embed_back(lab, info)
 
+            lab = self._embed_back(arrays, info)
+            lab = self._to_labels(lab)
+            
             if bmz_id == "conscientious-seashell":
                 H0, W0 = int(info["H0"]), int(info["W0"])
                 h, w = lab.shape[:2]

--- a/midap/segmentation/bmz_segmentator_jupyter.py
+++ b/midap/segmentation/bmz_segmentator_jupyter.py
@@ -167,7 +167,7 @@ class BMZSegmentationJupyter(base_segmentator.SegmentationPredictor):
             #p = np.asarray(out_arrays["output0"])
             #p2d = self._extract_2d(p, prefer_foreground=True).astype("float32")
 
-            p = _as_2d_prof(np.asarray(out_arrays["output0"]))
+            p = _as_2d_prob(np.asarray(out_arrays["output0"]))
 
             if p.size == 0 or float(p.max()) == float(p.min()):
                 return np.zeros_like(p, dtype=np.uint32)

--- a/midap/segmentation/bmz_segmentator_jupyter.py
+++ b/midap/segmentation/bmz_segmentator_jupyter.py
@@ -223,7 +223,7 @@ class BMZSegmentationJupyter(base_segmentator.SegmentationPredictor):
             arrays = sample.as_arrays()  
 
             lab = self._to_labels(arrays)
-            lab = self._embed_back(lab, info)
+            #lab = self._embed_back(lab, info)
 
             if bmz_id == "conscientious-seashell":
                 H0, W0 = int(info["H0"]), int(info["W0"])

--- a/midap/segmentation/bmz_segmentator_jupyter.py
+++ b/midap/segmentation/bmz_segmentator_jupyter.py
@@ -152,7 +152,6 @@ class BMZSegmentationJupyter(base_segmentator.SegmentationPredictor):
         def _as_2d_prob(arr):
             return self._extract_2d(arr, prefer_foreground=True).astype("float32")
         
-        # --- explicit handling for idealistic-water-buffalo: 2-channel prob maps in 'output0'
         if "output0" in out_arrays:
             a = np.asarray(out_arrays["output0"])
             # reduce to 2D: pick the likely foreground channel from (C,H,W)
@@ -173,26 +172,26 @@ class BMZSegmentationJupyter(base_segmentator.SegmentationPredictor):
             from skimage.measure import label
             return label(mask).astype(np.uint32)
             
-        if "masks" in out_arrays:
-            m = np.asarray(_as_2d_any(out_arrays["masks"]))
-            if m.ndim == 2:
-                if m.dtype.kind in "ui":
-                    return m.astype(np.uint32)
-                if m.dtype.kind == "f":
-                    maxv = float(m.max()) if m.size else 0.0
-                    if maxv > 1.5 and np.allclose(m, np.round(m), atol=1e-3):
-                        return np.round(m).astype(np.uint32)
-                    thr = float(m.mean() + 0.5 * m.std())
-                    mask = remove_small_objects(m > thr, 16)
-                    return label(mask).astype(np.uint32)
-                    
+        #if "masks" in out_arrays:
+        #    m = np.asarray(_as_2d_any(out_arrays["masks"]))
+        #    if m.ndim == 2:
+        #        if m.dtype.kind in "ui":
+        #            return m.astype(np.uint32)
+        #        if m.dtype.kind == "f":
+        #            maxv = float(m.max()) if m.size else 0.0
+        #            if maxv > 1.5 and np.allclose(m, np.round(m), atol=1e-3):
+        #                return np.round(m).astype(np.uint32)
+        #            thr = float(m.mean() + 0.5 * m.std())
+        #            mask = remove_small_objects(m > thr, 16)
+        #            return label(mask).astype(np.uint32)
+        
 
-        for v in out_arrays.values():
-            if isinstance(v, np.ndarray):
-                a2d = _as_2d_prob(v)
-                thr = a2d.mean() + 0.5 * a2d.std()
-                mask = remove_small_objects(a2d > thr, 16)
-                return label(mask).astype(np.uint32)
+        #for v in out_arrays.values():
+        #    if isinstance(v, np.ndarray):
+        #        a2d = _as_2d_prob(v)
+        #        thr = a2d.mean() + 0.5 * a2d.std()
+        #        mask = remove_small_objects(a2d > thr, 16)
+        #        return label(mask).astype(np.uint32)
 
         raise RuntimeError("BMZ model produced no array outputs to convert.")
 

--- a/midap/segmentation/bmz_segmentator_jupyter.py
+++ b/midap/segmentation/bmz_segmentator_jupyter.py
@@ -223,7 +223,7 @@ class BMZSegmentationJupyter(base_segmentator.SegmentationPredictor):
             arrays = sample.as_arrays()  
 
             lab = self._to_labels(arrays)
-            #lab = self._embed_back(lab, info)
+            lab = self._embed_back(lab, info)
 
             if bmz_id == "conscientious-seashell":
                 H0, W0 = int(info["H0"]), int(info["W0"])

--- a/midap/segmentation/bmz_segmentator_jupyter.py
+++ b/midap/segmentation/bmz_segmentator_jupyter.py
@@ -155,7 +155,7 @@ class BMZSegmentationJupyter(base_segmentator.SegmentationPredictor):
         if "output0" in out_arrays:
             a = np.asarray(out_arrays["output0"])
             # reduce to 2D: pick the likely foreground channel from (C,H,W)
-            a2d = self._extract_2d(a, prefer_foreground=False).astype("float32")
+            a2d = self._extract_2d(a, prefer_foreground=True).astype("float32")
             try:
                 from skimage.filters import threshold_otsu
                 thr = float(threshold_otsu(a2d))


### PR DESCRIPTION
## Sanity check on yesterday's addition of  🦆 `jolly-duck` (mitochondria segmentation)

+ slight changes on the way probability maps are turned into  instance labels. --> ignore small gaps, holes, etc. Overall improve the thresholding

+ ⚠️ NOTE: should do the same for `idealistic-water-buffalo` 🐃 
+ ⚠️  ⚠️ NOTE 2: issues with inference time insist. Not sure they are 'real'. More later.