### PR TITLE
improving instance labels for BMZ models

### DIFF
--- a/midap/segmentation/bmz_segmentator_jupyter.py
+++ b/midap/segmentation/bmz_segmentator_jupyter.py
@@ -289,7 +289,7 @@ class BMZSegmentationJupyter(base_segmentator.SegmentationPredictor):
                 raise RuntimeError(f"Unexpected output0 shape: {arrays.shape}")
 
             y = {"output0": arrays}
-            lab = to_labels(y)
+            lab = self._to_labels(y)
             
             #lab = self._embed_back(arrays, info)
             #lab = self._to_labels(lab)


### PR DESCRIPTION
## probability maps --> instance labels

+ I have altered slightly the way that the output of `jolly-duck` and `idealistic-water-buffalo` are translated into instance labels (with the hope to improve them)
    + more specifically: 🦆 outputs only one channel (probabilities) whereas 🐃 returns 2 channels (probabilities and boundaries). For the :duck I use simply an otsu threshold to create a foreground bianry amsk, and do small correction to remove pinhole gaps, etc. For the 🐃 (or other models with a 2-channel output or probabilities + boundaries) on top of the otsu, I do a watershed by utilizing the boundary info.

+ ⚠️ ATTENTION ideally, i shouldn't be adding 'interpretation' of the models' outputs (meaning that models that produce instance masks themselves should be preferred). Also, the probability maps - to - instance labels implementation I used, should probably be replaced by something already 'standard'. Perhaps borrow the code from commonly-used software that implements watershed for this type of segmentation? I am at the moment agnostic as to what that would be --> should read on it or ask someone who knows (Szymon? Simon?)

