### PR TITLE
simplify display model names on all field of UI

### DIFF
--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -652,9 +652,9 @@ class SegmentationJupyter(object):
         for nnt, models in self.all_chosen_seg_models.items():
             self.select_segmentator(nnt)
             for model in models:
-                model_name = "_".join((model).split("_")[2:])
                 key = f"{nnt}_{model}"
-                #model_name = re.sub(r"^model_weights_|midap_", "", model)
+                model_name = "_".join((model).split("_")[2:])
+                UI_model_name = re.sub(r"^model_weights_|midap_", "", model)
 
                 
                 #----------- dead time while fetching  (BioImage Zoo)) model weights ---------#
@@ -682,7 +682,7 @@ class SegmentationJupyter(object):
 
                 # ---- time inference summary table ---------
                 rows.append({
-                    "Model": model_name,
+                    "Model": UI_model_name,
                     "Images": n_imgs,
                     "Total time (s)": elapsed,
                     "Images / s": (n_imgs / elapsed) if elapsed > 0 else float("inf"),

--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -877,8 +877,8 @@ class SegmentationJupyter(object):
             # ---- bar plot: mean disagreements + std dev ----
                 mdl_ids = list(self.model_diff_scores.keys())
                 scores, std_devs = zip(*[self.model_diff_scores[m] for m in mdl_ids])
-                #short_mdl_ids = [f"{m[:5]}...{m.split('_')[-1]}" for m in mdl_ids]
-                short_mdl_ids = [str(k).split("_model_weights_", 1)[-1] for k in mdl_ids]
+                #short_mdl_ids = [str(k).split("_model_weights_", 1)[-1] for k in mdl_ids]
+                short_mdl_ids = [re.sub(r"^(?:.*?)_(?:model_weights|midap)_", "", str(k)) for k in mdl_ids]
             
                 ax6.bar(range(len(mdl_ids)), scores, yerr=std_devs, width=0.35, capsize=8)
                 ax6.set_xticks(range(len(mdl_ids)))

--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -653,8 +653,9 @@ class SegmentationJupyter(object):
             self.select_segmentator(nnt)
             for model in models:
                 #model_name = "_".join((model).split("_")[2:])
-                model_name = re.sub(r"^model_weights_|midap_", "", model)
                 key = f"{nnt}_{model}"
+                model_name = re.sub(r"^model_weights_|midap_", "", model)
+
                 
                 #----------- dead time while fetching  (BioImage Zoo)) model weights ---------#
                 #----------- do not count it as inference time -------------------------------#

--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -877,7 +877,6 @@ class SegmentationJupyter(object):
             # ---- bar plot: mean disagreements + std dev ----
                 mdl_ids = list(self.model_diff_scores.keys())
                 scores, std_devs = zip(*[self.model_diff_scores[m] for m in mdl_ids])
-                #short_mdl_ids = [str(k).split("_model_weights_", 1)[-1] for k in mdl_ids]
                 short_mdl_ids = [re.sub(r"^(?:.*?)_(?:model_weights|midap)_", "", str(k)) for k in mdl_ids]
             
                 ax6.bar(range(len(mdl_ids)), scores, yerr=std_devs, width=0.35, capsize=8)
@@ -894,7 +893,6 @@ class SegmentationJupyter(object):
             list_names = []
             for k in keys:
                 s = str(k)
-                #s = s.split("_model_weights_", 1)[1] 
                 s = re.sub(r'^.*?_(?:model_weights|midap)_', '', s)
                 list_names.append((s, k))  
             
@@ -1175,8 +1173,7 @@ class SegmentationJupyter(object):
             self.make_cutouts()
             self.save_cutouts()
 
-        #self.select_segmentator(self.out_weights.label.split("_")[0])
-        #self.segment_all_images(("_").join(self.out_weights.label.split("_")[3:]))
+
         self.select_segmentator(self.out_weights.value.split("_")[0])
         self.segment_all_images(("_").join(self.out_weights.value.split("_")[3:]))
         self.save_segs()

--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -651,7 +651,8 @@ class SegmentationJupyter(object):
         for nnt, models in self.all_chosen_seg_models.items():
             self.select_segmentator(nnt)
             for model in models:
-                model_name = "_".join((model).split("_")[2:])
+                #model_name = "_".join((model).split("_")[2:])
+                model_name = re.sub(r"^model_weights_|midap_", "", model)
                 key = f"{nnt}_{model}"
                 
                 #----------- dead time while fetching  (BioImage Zoo)) model weights ---------#

--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -894,7 +894,8 @@ class SegmentationJupyter(object):
             list_names = []
             for k in keys:
                 s = str(k)
-                s = s.split("_model_weights_", 1)[1] 
+                #s = s.split("_model_weights_", 1)[1] 
+                s = re.sub(r'^.*?_(?:model_weights|midap)_', '', s)
                 list_names.append((s, k))  
             
             controls = widgets.VBox([

--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -874,8 +874,9 @@ class SegmentationJupyter(object):
             # ---- bar plot: mean disagreements + std dev ----
                 mdl_ids = list(self.model_diff_scores.keys())
                 scores, std_devs = zip(*[self.model_diff_scores[m] for m in mdl_ids])
-                short_mdl_ids = [f"{m[:5]}...{m.split('_')[-1]}" for m in mdl_ids]
-
+                #short_mdl_ids = [f"{m[:5]}...{m.split('_')[-1]}" for m in mdl_ids]
+                short_mdl_ids = [str(k).split("_model_weights_", 1)[-1] for k in mdl_ids]
+            
                 ax6.bar(range(len(mdl_ids)), scores, yerr=std_devs, width=0.35, capsize=8)
                 ax6.set_xticks(range(len(mdl_ids)))
                 ax6.set_xticklabels(short_mdl_ids, rotation=45, ha="right")

--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -652,9 +652,9 @@ class SegmentationJupyter(object):
         for nnt, models in self.all_chosen_seg_models.items():
             self.select_segmentator(nnt)
             for model in models:
-                #model_name = "_".join((model).split("_")[2:])
+                model_name = "_".join((model).split("_")[2:])
                 key = f"{nnt}_{model}"
-                model_name = re.sub(r"^model_weights_|midap_", "", model)
+                #model_name = re.sub(r"^model_weights_|midap_", "", model)
 
                 
                 #----------- dead time while fetching  (BioImage Zoo)) model weights ---------#

--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -1113,8 +1113,18 @@ class SegmentationJupyter(object):
         """
         Displays all used models for segmentation to select best model.
         """
+        def pretty_label(k) -> str:
+        # show a cleaned label but keep the original key as the widget value
+            s = str(k)
+            return re.sub(r'^.*?_(?:model_weights|midap)_', '', s)
+        
+        keys = list(self.dict_all_models.keys())
+        options = [(pretty_label(k), k) for k in keys]   # (display label, internal value)
+
+        
         self.out_weights = widgets.RadioButtons(
-            options=list(self.dict_all_models.keys()),
+            #options=list(self.dict_all_models.keys()),
+            options=options,
             description="Model weights:",
             disabled=False,
             layout=widgets.Layout(width="100%"),

--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -1113,14 +1113,13 @@ class SegmentationJupyter(object):
         """
         Displays all used models for segmentation to select best model.
         """
-        def pretty_label(k) -> str:
+        def display_mdl_label(k) -> str:
         # show a cleaned label but keep the original key as the widget value
             s = str(k)
             return re.sub(r'^.*?_(?:model_weights|midap)_', '', s)
         
         keys = list(self.dict_all_models.keys())
-        options = [(pretty_label(k), k) for k in keys]   # (display label, internal value)
-
+        options = [(display_mdl_label(k), k) for k in keys]   
         
         self.out_weights = widgets.RadioButtons(
             #options=list(self.dict_all_models.keys()),
@@ -1176,8 +1175,10 @@ class SegmentationJupyter(object):
             self.make_cutouts()
             self.save_cutouts()
 
-        self.select_segmentator(self.out_weights.label.split("_")[0])
-        self.segment_all_images(("_").join(self.out_weights.label.split("_")[3:]))
+        #self.select_segmentator(self.out_weights.label.split("_")[0])
+        #self.segment_all_images(("_").join(self.out_weights.label.split("_")[3:]))
+        self.select_segmentator(self.out_weights.value.split("_")[0])
+        self.segment_all_images(("_").join(self.out_weights.value.split("_")[3:]))
         self.save_segs()
 
     def save_segs(self):

--- a/midap/midap_jupyter/segmentation_jupyter.py
+++ b/midap/midap_jupyter/segmentation_jupyter.py
@@ -2,6 +2,7 @@ import os
 import sys
 import shutil
 import time
+import re
 
 from skimage import io
 from pathlib import Path


### PR DESCRIPTION
## Simplify model names

Internal naming of models is complex and long: various prefixes to direct the choise of segmentator, model weights, etc, etc. However, this makes for cumbersome display names and user confusion. 
instead of re-doing the naming, the names are kept as they were, for all internal uses. ONLY display names are shortened, for space economy and friendlier UI experience.